### PR TITLE
Fix Trimmomatic R2 input

### DIFF
--- a/QCD.smk
+++ b/QCD.smk
@@ -156,7 +156,7 @@ rule quality_raw:
 rule trimmomatic_pe:
     input:
         r1 = lambda wildcards: expand(str(config["short_reads"] + "/" + f"{wildcards.sample}_R1.fastq.gz")),
-        r2 = lambda wildcards: expand(str(config["short_reads"] + "/" + f"{wildcards.sample}_R1.fastq.gz")),
+        r2 = lambda wildcards: expand(str(config["short_reads"] + "/" + f"{wildcards.sample}_R2.fastq.gz")),
         
     output:
         r1 = f"results/{{prefix}}/{{sample}}/trimmomatic/{{sample}}_R1_trim_paired.fastq.gz",


### PR DESCRIPTION
Currently the R1 FASTQ is being passed to Trimmomatic twice, so the result is that both the trimmed R1 and R2 FASTQs are actually the trimmed R1.